### PR TITLE
wip: preload queries automatically

### DIFF
--- a/app/components/link.tsx
+++ b/app/components/link.tsx
@@ -1,12 +1,93 @@
-import {forwardRef, type AnchorHTMLAttributes} from 'react';
-import {createLink} from '@tanstack/react-router';
+import {useEffect, useMemo, useRef} from 'react';
+import {
+  LinkComponent,
+  Link as TanstackLink,
+  useRouter,
+} from '@tanstack/react-router';
+import {Query, Zero} from '@rocicorp/zero';
+import {useZero} from '@rocicorp/zero/react';
+import {Schema} from 'zero/schema';
+import {useSession, SessionContextType} from 'app/components/session-provider';
 
-interface MouseDownLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {}
+type RouteQuery = (
+  z: Zero<Schema>,
+  params?: Record<string, string> | undefined,
+  search?: Record<string, any> | undefined,
+  session?: SessionContextType | undefined,
+) => Query<Schema, keyof Schema['tables'], any>;
 
-const MouseDownLinkComponent = forwardRef<
-  HTMLAnchorElement,
-  MouseDownLinkProps
->(({onMouseDown, onClick, ...rest}, ref) => {
+declare module '@tanstack/react-router' {
+  interface StaticDataRouteOption {
+    query?: RouteQuery | undefined;
+  }
+}
+
+export const Link: LinkComponent<typeof TanstackLink> = ({
+  onMouseDown,
+  onClick,
+  to,
+  params,
+  search,
+  ...rest
+}) => {
+  // OK, the reason to do all of this manually rather than using the built-in
+  // preload feature is that our desired semantics are a bit different than
+  // classic APIs:
+  //
+  // - Materializing the query is the most expensive thing. Maintaining it is
+  //   relatively cheap. So once we've materialized the query, we don't want
+  //   to accidentally throw it away if user will end up needing it. So a
+  //   fixed timeout like 5m, which is what built-in TS features do is
+  //   non-ideal.
+  //
+  // - If the user re-views a link shortly after it was last viewed, we want
+  //   to avoid re-materializing the query. Hence we do want a timeout, but
+  //   it should start *after* the link is unmounted.
+  const z = useZero<Schema>();
+  const session = useSession();
+  const ref = useRef<HTMLAnchorElement>(null);
+  const router = useRouter();
+  const location = useMemo(() => {
+    return router.buildLocation({
+      to: to as any,
+      params,
+      search,
+    });
+  }, [to, params, search]);
+
+  useEffect(() => {
+    // TODO: This is marked deprecated in my editor, but according to .d.ts,
+    // I think this siganture is valid.
+    //
+    // Also is this the correct way to do all this?
+    //
+    // TODO: Is there a way to disable strict mode and prevent all these queries
+    // from getting called twice in dev mode. It's not a big deal because Zero
+    // does dedupe them but it makes the network monitor hard to read.
+    const matches = router.matchRoutes(location);
+    const match = matches[matches.length - 1];
+    if (!match) {
+      console.info('No match found for location - not preloading', location);
+      return;
+    }
+
+    const route = to && router.routesById[match.routeId];
+    const queryFn = route?.options.staticData?.query as RouteQuery | undefined;
+    if (!queryFn) {
+      console.info('No query found for route - not preloading', route.id);
+      return;
+    }
+
+    const query = queryFn(z, match.params, match.search, session);
+    const {cleanup} = query.preload({
+      ttl: '5m',
+    });
+
+    return () => {
+      cleanup();
+    };
+  }, [location]);
+
   const handleMouseDown = e => {
     if (onMouseDown) {
       onMouseDown(e);
@@ -16,12 +97,18 @@ const MouseDownLinkComponent = forwardRef<
         onClick(e);
       }
     }
+    ref.current?.click();
   };
 
   return (
-    <a ref={ref} {...rest} onMouseDown={handleMouseDown} onClick={onClick} />
+    <TanstackLink
+      ref={ref}
+      to={to as any}
+      params={params}
+      search={search}
+      onMouseDown={handleMouseDown}
+      onClick={onClick}
+      {...rest}
+    />
   );
-});
-MouseDownLinkComponent.displayName = 'MouseDownLinkComponent';
-
-export const Link = createLink(MouseDownLinkComponent);
+};

--- a/app/routes/_layout/cart.tsx
+++ b/app/routes/_layout/cart.tsx
@@ -3,24 +3,35 @@ import {createFileRoute} from '@tanstack/react-router';
 import {Mutators} from 'zero/mutators';
 import {Schema} from 'zero/schema';
 import {Button} from 'app/components/button';
-import {useSession} from 'app/components/session-provider';
+import {SessionContextType, useSession} from 'app/components/session-provider';
+import {Zero} from '@rocicorp/zero';
+
+function query(
+  z: Zero<Schema>,
+  _params: undefined,
+  _search: undefined,
+  session: SessionContextType,
+) {
+  return z.query.cartItem
+    .related('album', album =>
+      album.one().related('artist', artist => artist.one()),
+    )
+    .where('userId', session.data?.userID ?? '')
+    .orderBy('addedAt', 'asc');
+}
 
 export const Route = createFileRoute('/_layout/cart')({
   component: RouteComponent,
   ssr: false,
+  staticData: {
+    query,
+  },
 });
 
 function RouteComponent() {
   const session = useSession();
   const z = useZero<Schema, Mutators>();
-  const [cartItems] = useQuery(
-    z.query.cartItem
-      .related('album', album =>
-        album.one().related('artist', artist => artist.one()),
-      )
-      .where('userId', session.data?.userID ?? ''),
-  );
-
+  const [cartItems] = useQuery(query(z, undefined, undefined, session));
   if (!session.data) {
     return <div>Login to view cart</div>;
   }

--- a/app/routes/_layout/index.tsx
+++ b/app/routes/_layout/index.tsx
@@ -3,7 +3,6 @@ import {type Schema} from 'zero/schema';
 import {createFileRoute, useRouter} from '@tanstack/react-router';
 import {useEffect, useState} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
-import {artistQuery} from './artist';
 import {Link} from 'app/components/link';
 
 export const Route = createFileRoute('/_layout/')({
@@ -27,16 +26,12 @@ function Home() {
     setSearch(searchParam ?? '');
   }, [searchParam]);
 
-  let q = artistQuery(z.query.artist)
-    .orderBy('popularity', 'desc')
-    .limit(limit);
+  let q = z.query.artist.orderBy('popularity', 'desc').limit(limit);
   if (search) {
     q = q.where('name', 'ILIKE', `%${search}%`);
   }
 
   const [artists, {type}] = useQuery(q, {ttl: '1m'});
-
-  console.time('artists - ' + type);
 
   const setSearchParam = useDebouncedCallback((text: string) => {
     router.navigate({


### PR DESCRIPTION
In retrospect I am second-guessing whether this is the right thing.

While it *is* annoying that we will have to just cache queries for 5min, rather than being precise, using the built-in loader stuff gets many things for free:

- According to docs, there's a way to disable the double query that gets sent and dirties up the network logs. Even if it's just a matter of a ttl at the tanstack level, that works fine since our queries are reactive - they never get stale. The TS ttl will just be to avoid re *creating* the query.

- All the typesafety goop comes for free.

- Uses the loader concept that TS users are maybe already familiar with.

- Plugs into the intersection/render other preload options.