### PR TITLE
Demonstrate request IP in Zero mutator context

### DIFF
--- a/app/components/zero-init.tsx
+++ b/app/components/zero-init.tsx
@@ -18,7 +18,9 @@ const logLevel = import.meta.env.VITE_PUBLIC_ZERO_LOG_LEVEL;
 export function ZeroInit({children}: {children: React.ReactNode}) {
   const router = useRouter();
   const session = authClient.useSession();
-  const context = session.data ? {userId: session.data.user.id} : undefined;
+  const context = session.data
+    ? {userId: session.data.user.id, clientIP: undefined}
+    : undefined;
   const userID = session.data?.user.id ?? null;
 
   const init = useCallback(

--- a/app/routes/api/mutators/$.ts
+++ b/app/routes/api/mutators/$.ts
@@ -6,6 +6,7 @@ import postgres from 'postgres';
 import {auth} from 'auth/auth';
 import {must} from 'shared/must';
 import {mutators} from 'zero/mutators';
+import {createRequestContext} from 'zero/request-context';
 import {schema} from 'zero/schema';
 
 const pgURL = must(process.env.PG_URL, 'PG_URL is required');
@@ -114,14 +115,17 @@ export const Route = createFileRoute('/api/mutators/$')({
         try {
           mutator = mustGetMutator(mutators, mutatorName);
         } catch {
-          return json({error: `Unknown mutator: ${mutatorName}`}, {status: 404});
+          return json(
+            {error: `Unknown mutator: ${mutatorName}`},
+            {status: 404},
+          );
         }
 
         try {
           await dbProvider.transaction(async tx => {
             await mutator.fn({
               tx,
-              ctx: {userId: session.user.id},
+              ctx: createRequestContext({request, userId: session.user.id}),
               args,
             });
           });

--- a/app/routes/api/zero/mutate.ts
+++ b/app/routes/api/zero/mutate.ts
@@ -8,6 +8,7 @@ import {createFileRoute} from '@tanstack/react-router';
 import {auth} from 'auth/auth';
 import {mutators} from 'zero/mutators';
 import {mustGetMutator} from '@rocicorp/zero';
+import {createRequestContext} from 'zero/request-context';
 
 const pgURL = must(process.env.PG_URL, 'PG_URL is required');
 
@@ -23,7 +24,10 @@ export const Route = createFileRoute('/api/zero/mutate')({
           return json({error: 'Unauthorized'}, {status: 401});
         }
 
-        const ctx = {userId: session.user.id};
+        const ctx = createRequestContext({
+          request,
+          userId: session.user.id,
+        });
 
         return json(
           await handleMutateRequest({

--- a/app/routes/api/zero/query.ts
+++ b/app/routes/api/zero/query.ts
@@ -5,13 +5,16 @@ import {auth} from 'auth/auth';
 import {handleQueryRequest} from '@rocicorp/zero/server';
 import {mustGetQuery} from '@rocicorp/zero';
 import {queries} from 'zero/queries';
+import {createRequestContext} from 'zero/request-context';
 
 export const Route = createFileRoute('/api/zero/query')({
   server: {
     handlers: {
       POST: async ({request}) => {
         const session = await auth.api.getSession(request);
-        const ctx = session ? {userId: session.user.id} : undefined;
+        const ctx = session
+          ? createRequestContext({request, userId: session.user.id})
+          : undefined;
         return json(
           await handleQueryRequest({
             handler: (name, args) => {

--- a/zero/auth.ts
+++ b/zero/auth.ts
@@ -1,6 +1,7 @@
 export type Context =
   | {
       userId: string;
+      clientIP: string | undefined;
     }
   | undefined;
 

--- a/zero/mutators.ts
+++ b/zero/mutators.ts
@@ -1,6 +1,7 @@
 import {zql} from './schema';
 import z from 'zod';
 import {defineMutator, defineMutators} from '@rocicorp/zero';
+import type {Context} from './auth';
 
 export const mutatorValidators = {
   cart: {
@@ -14,10 +15,10 @@ export const mutators = defineMutators({
     add: defineMutator(
       mutatorValidators.cart.add,
       async ({tx, ctx, args: {albumId, addedAt}}) => {
-        if (!ctx) {
-          throw new Error('Not authenticated');
+        const {userId, clientIP} = requireAuthContext(ctx);
+        if (tx.location === 'server') {
+          auditCartMutation({action: 'add', userId, clientIP});
         }
-        const {userId} = ctx;
         await tx.mutate.cartItem.insert({
           userId,
           albumId,
@@ -29,10 +30,10 @@ export const mutators = defineMutators({
     remove: defineMutator(
       mutatorValidators.cart.remove,
       async ({tx, ctx, args: {albumId}}) => {
-        if (!ctx) {
-          throw new Error('Not authenticated');
+        const {userId, clientIP} = requireAuthContext(ctx);
+        if (tx.location === 'server') {
+          auditCartMutation({action: 'remove', userId, clientIP});
         }
-        const {userId} = ctx;
         const cartItem = await tx.run(
           zql.cartItem.where('userId', userId).where('albumId', albumId).one(),
         );
@@ -47,3 +48,22 @@ export const mutators = defineMutators({
     ),
   },
 });
+
+function requireAuthContext(ctx: Context): NonNullable<Context> {
+  if (!ctx) {
+    throw new Error('Not authenticated');
+  }
+  return ctx;
+}
+
+function auditCartMutation({
+  action,
+  userId,
+  clientIP,
+}: {
+  action: 'add' | 'remove';
+  userId: string;
+  clientIP: string | undefined;
+}) {
+  console.info('cart mutation', {action, userId, clientIP});
+}

--- a/zero/request-context.ts
+++ b/zero/request-context.ts
@@ -1,0 +1,27 @@
+import type {Context} from './auth';
+
+export function createRequestContext({
+  request,
+  userId,
+}: {
+  request: Request;
+  userId: string;
+}): Context {
+  return {
+    userId,
+    clientIP: getClientIP(request),
+  };
+}
+
+function getClientIP(request: Request): string | undefined {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    return forwardedFor.split(',').at(0)?.trim() || undefined;
+  }
+
+  return (
+    request.headers.get('x-real-ip')?.trim() ||
+    request.headers.get('cf-connecting-ip')?.trim() ||
+    undefined
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a typed request context helper that reads the client IP from `x-forwarded-for`, `x-real-ip`, or `cf-connecting-ip`.
- Passes that context through the Zero mutate endpoint and the sample direct mutator endpoint.
- Demonstrates consuming `ctx.clientIP` inside the cart mutators for server-side audit logging.

## Verification
- `node --run build` passed.
- `./node_modules/.bin/tsc --noEmit` still reports existing TanStack Start config/API type errors in `app/ssr.tsx` and `vite.config.ts`, unrelated to this change.

## Note
This is meant to show that apps can put request-derived data on their own Zero `Context`; it does not require a Zero framework change.